### PR TITLE
Made animation props optional

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -333,9 +333,9 @@ export default function Zoom(props: PropsWithChildren<ZoomProps>): React.ReactNo
 export interface ZoomProps {
   style: StyleProp<ViewProps>;
   contentContainerStyle: StyleProp<ViewProps>;
-  animationConfig: object;
+  animationConfig?: object;
 
-  animationFunction<T extends AnimatableValue>(
+  animationFunction?<T extends AnimatableValue>(
     toValue: T,
     userConfig?: object,
     callback?: AnimationCallback,


### PR DESCRIPTION
Passing animation props can be optional according to the implementation. I forget it in my previous PR #9. this PR will fix it. 