### PR TITLE
made style props optional

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -331,8 +331,8 @@ export default function Zoom(props: PropsWithChildren<ZoomProps>): React.ReactNo
 }
 
 export interface ZoomProps {
-  style: StyleProp<ViewProps>;
-  contentContainerStyle: StyleProp<ViewProps>;
+  style?: StyleProp<ViewProps>;
+  contentContainerStyle?: StyleProp<ViewProps>;
   animationConfig?: object;
 
   animationFunction?<T extends AnimatableValue>(


### PR DESCRIPTION
Passing style props can be optional according to the implementation. I forget it in my previous PR #9. this PR will fix it. 