### PR TITLE
fix: doubleTap to zoom out fix

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -316,8 +316,7 @@ export function useZoomGesture(props: UseZoomGestureProps = {}): {
       })
 
     return Gesture.Exclusive(
-      Gesture.Simultaneous(pinchGesture, panGesture),
-      tapGesture
+      Gesture.Simultaneous(pinchGesture, panGesture, tapGesture)
     )
   }, [
     handlePanOutside,


### PR DESCRIPTION
Fixes double tap to zoom out on Samsung devices, which was not working.