### PR TITLE
fix:render error with gesture detector

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import {
   ComposedGesture,
   Gesture,
   GestureDetector,
+  GestureHandlerRootView,
   GestureStateChangeEvent,
   GestureTouchEvent,
   GestureUpdateEvent,
@@ -438,20 +439,22 @@ export default function Zoom(
   })
 
   return (
-    <GestureDetector gesture={zoomGesture}>
-      <View
-        style={[styles.container, style]}
-        onLayout={onLayout}
-        collapsable={false}
-      >
-        <Animated.View
-          style={[contentContainerAnimatedStyle, contentContainerStyle]}
-          onLayout={onLayoutContent}
+    <GestureHandlerRootView>
+      <GestureDetector gesture={zoomGesture}>
+        <View
+          style={[styles.container, style]}
+          onLayout={onLayout}
+          collapsable={false}
         >
-          {children}
-        </Animated.View>
-      </View>
-    </GestureDetector>
+          <Animated.View
+            style={[contentContainerAnimatedStyle, contentContainerStyle]}
+            onLayout={onLayoutContent}
+          >
+            {children}
+          </Animated.View>
+        </View>
+      </GestureDetector>
+    </GestureHandlerRootView>
   )
 }
 


### PR DESCRIPTION
Fix for the error `Render Error: GestureDetector must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized.`

Wrapped the GestureDetector component inside "index.tsx" with the GestureHandlerRootView component. That solves the issue #38  