### PR TITLE
fix: react 19 types for useRef

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@react-native-community/eslint-config": "^3.2.0",
-    "@types/react": "^18.2.45",
+    "@types/react": "^18.2.45 || ^19.0.0",
     "@types/react-native": "^0.72.8",
     "eslint": "^8.56.0",
     "eslint-plugin-import": "^2.29.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -77,7 +77,7 @@ export function useZoomGesture(props: UseZoomGestureProps = {}): {
 
   const handlePanOutsideTimeoutId: React.MutableRefObject<
     ReturnType<typeof setTimeout> | undefined
-  > = useRef()
+  > = useRef(undefined)
 
   const withAnimation = useCallback(
     (toValue: number, config?: AnimationConfigProps) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,13 +1106,11 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@^18.2.45":
-  version "18.2.45"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.45.tgz#253f4fac288e7e751ab3dc542000fb687422c15c"
-  integrity sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==
+"@types/react@^18.2.45 || ^19.0.0":
+  version "19.1.10"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.1.10.tgz#a05015952ef328e1b85579c839a71304b07d21d9"
+  integrity sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==
   dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/scheduler@*":


### PR DESCRIPTION
When using with React 19+, this trigger a TS error (if you don't use `skipLibCheck`). 

`useRef` now enforce passing an initial value. See https://github.com/eps1lon/types-react-codemod/?tab=readme-ov-file#useref-required-initial-react-19 for more information!

This PR adds support for this, and this should not be a breaking change as this does not alter the runtime behavior 